### PR TITLE
Fix for Blowfish Usage With Short Key

### DIFF
--- a/cripto-resource/src/main/java/com/novatronic/cripto/resource/SignatureResource.java
+++ b/cripto-resource/src/main/java/com/novatronic/cripto/resource/SignatureResource.java
@@ -57,7 +57,7 @@ public class SignatureResource {
 
     public boolean verify(String datafile, PublicKey pubKey, String sigbytes) throws NoSuchAlgorithmException, InvalidKeyException, IOException, SignatureException {
         KeyGenerator keyGenerator = KeyGenerator.getInstance("Blowfish");
-        keyGenerator.init(96);
+        keyGenerator.init(128);
         Key blowfishKey = keyGenerator.generateKey();
         
         FileInputStream fis = new FileInputStream(datafile);


### PR DESCRIPTION
[Issue Link](http://localhost/issues/eyJ0YWdfaWQiOiB7InJlcG9zaXRvcnlfaWQiOiB7InByb3ZpZGVyX2lkIjogIkdpdGh1YiIsICJwcm92aWRlcl9vd25lcl9pZCI6ICI1Mjc1NDAwMyIsICJwcm92aWRlcl9yZXBvc2l0b3J5X2lkIjogIk1ERXdPbEpsY0c5emFYUnZjbmt5TXpJMk16WTJNelU9In0sICJuYW1lIjogIm9yaWdpbi9IRUFEIn0sICJyZXBvcnRfaWQiOiAxOTU3fQ%3D%3D?issue_id=eyJyZXBvcnRfaWQiOiB7InRhZ19pZCI6IHsicmVwb3NpdG9yeV9pZCI6IHsicHJvdmlkZXJfaWQiOiAiR2l0aHViIiwgInByb3ZpZGVyX293bmVyX2lkIjogIjUyNzU0MDAzIiwgInByb3ZpZGVyX3JlcG9zaXRvcnlfaWQiOiAiTURFd09sSmxjRzl6YVhSdmNua3lNekkyTXpZMk16VT0ifSwgIm5hbWUiOiAib3JpZ2luL0hFQUQifSwgInJlcG9ydF9pZCI6IDE5NTd9LCAiaXNzdWVfaWQiOiAxODkzMH0%3D)

The Blowfish cipher supports key sizes from 32 bits to 448 bits. Small key sizes make the ciphertext vulnerable to brute force attacks. At least 128 bits of entropy should be used when generating the key if the use of Blowfish is required.

Vulnerable Code:
```
KeyGenerator keyGen = KeyGenerator.getInstance("Blowfish");
keyGen.init(64);
```

Solution:
```
KeyGenerator keyGen = KeyGenerator.getInstance("Blowfish");
keyGen.init(128);
```

If the algorithm can be changed, the AES block cipher should be used instead.